### PR TITLE
update nodejs version from 12 to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ outputs:
   comment_body:
     description: The comment body.
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: check-circle


### PR DESCRIPTION
Updates the nodejs version from 12 to 16 as suggested from GitHub: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/