### PR TITLE
GitHub Actions: All Actions will begin running on Node16 instead of Node12

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ outputs:
   comment_body:
     description: The comment body.
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: check-circle


### PR DESCRIPTION
Hi! 

Please consider this update of `node12` to `node16` as suggested by GitHub.

[GitHub Actions: All Actions will begin running on Node16 instead of Node12](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)

> September 22, 2022
> 
> **Node 12 has been out of support since [April 2022](https://github.com/nodejs/Release/#end-of-life-releases)**, as a result we have started the **deprecation process of Node 12 for GitHub Actions**. We plan to **migrate all actions to run on Node16 by Summer 2023**. We will monitor the progress of the migration and listen to the community for how things are going before we define a final date.
> To raise awareness of the upcoming change, we are adding a warning into workflows which contain Actions running on Node 12. This will come into effect **starting on September 27th**.

When this action runs, it is displaying an alert about the deprecation of `node12`.

```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: khan/pull-request-comment-trigger@master
```

Thank you very much and have a great week 😀
